### PR TITLE
Add parser test and protocol docs

### DIFF
--- a/docs/CRC_ALGORITHMS.md
+++ b/docs/CRC_ALGORITHMS.md
@@ -1,1 +1,20 @@
 # CRC Algorithms
+
+The firmware calculates a standard CRC-16-IBM checksum using polynomial
+`0xA001` and an initial value of `0xFFFF`.  The Python implementation can be
+found in `src/communication/crc.py`.
+
+Pseudo-code:
+
+```
+crc = 0xFFFF
+for byte in data:
+    crc ^= byte
+    for _ in range(8):
+        if crc & 1:
+            crc = (crc >> 1) ^ 0xA001
+        else:
+            crc >>= 1
+return crc & 0xFFFF
+```
+

--- a/docs/DECOMPILE_NOTES.md
+++ b/docs/DECOMPILE_NOTES.md
@@ -15,6 +15,10 @@ This document tracks ongoing findings from reviewing `Fulldecompile.c` as outlin
 ## Serial Port Handling
 - References to `CSerialPort::vftable` appear near line 49184, suggesting an object-oriented serial port implementation.
 - Assertions reference `serialport.cpp`, hinting that this section was originally C++ source.
+- Function `FUN_00472f90` opens COM ports using `CreateFileA` with paths like
+  `\\.\\COM%d` and configures timeouts via `SetCommTimeouts`.
+- `GetCommState` and `SetCommState` manipulate a DCB structure to apply baud
+  rate and parity settings.
 
 ## Next Steps
 - Identify where packets are parsed by searching for length fields immediately following the start byte.

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -1,1 +1,11 @@
 # Parameter Map
+
+Known parameter IDs extracted so far.  These will expand as decompilation
+continues.
+
+| ID   | Name             | Units |
+|-----:|------------------|-------|
+|0x0001|`motor_speed_rpm` | rpm   |
+|0x0002|`bus_voltage_v`   | volts |
+|0x0003|`bus_current_a`   | amps  |
+

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,1 +1,18 @@
 # Communication Protocol
+
+Preliminary notes on the packet format used by Fardriver controllers as
+observed in the decompiled firmware.
+
+## Packet Structure
+
+| Byte | Description                               |
+|-----:|-------------------------------------------|
+| 0    | Start byte `0xAA`                         |
+| 1    | Length (`command` + `data` + CRC bytes)   |
+| 2    | Command identifier                        |
+| 3..N-3 | Payload bytes                           |
+| N-2..N-1 | CRC16-IBM (little endian) over bytes 0..N-3 |
+
+The length field matches the behaviour of :class:`DataParser` and therefore
+includes the command byte, payload bytes and the two CRC bytes.
+

--- a/src/communication/protocol.py
+++ b/src/communication/protocol.py
@@ -16,7 +16,10 @@ class Packet:
     data: bytes
 
     def encode(self) -> bytes:
-        length = len(self.data) + 2  # command + CRC
+        """Return an encoded protocol packet."""
+        # The length field includes the command byte, payload data and the two
+        # CRC bytes.  This matches the checks performed by :class:`DataParser`.
+        length = len(self.data) + 3
         payload = bytes([START_BYTE, length, self.command]) + self.data
         crc = crc16(payload)
         return payload + crc.to_bytes(2, "little")

--- a/tests/test_data_parser.py
+++ b/tests/test_data_parser.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import sys
+
+# Add repository root so that 'src' package can be imported
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.communication.protocol import Packet
+from src.parsing.data_parser import DataParser
+
+
+def test_data_parser_roundtrip():
+    packet = Packet(command=0x01, data=b"\x02\x03")
+    encoded = packet.encode()
+    parser = DataParser()
+    parsed = parser.parse(encoded)
+    assert parsed.command == 0x01
+    assert parsed.payload == b"\x02\x03"


### PR DESCRIPTION
## Summary
- document details about protocol packets and CRC
- log new findings in decompile notes
- note known parameter IDs
- improve Packet.encode length handling
- add unit test for DataParser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436ad2b24483209ac4b1328d22a7b6