### PR TITLE
Expand decompile notes and add streaming parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ The old version failed because it was incomplete. This version must expose EVERY
 
 Good luck, and remember: **This is life or death!** ⚡🏁
 ## NEXT STEPS
-- Continue mapping parameter offsets, starting with the RPM value at 0x9d40 and divisor at 0x9e84.
-- Expand `docs/PARAMETERS.md` with newly discovered IDs.
-- Implement streaming packet parsing once enough commands are known.
+- Document throttle and brake voltage offsets (`0x9d48` and `0xa074`).
+- Reverse configuration structures around `0x9e9c` for throttle mapping.
+- Integrate new ID/IQ current parameters into the UI.
 

--- a/docs/DECOMPILE_NOTES.md
+++ b/docs/DECOMPILE_NOTES.md
@@ -23,8 +23,20 @@ This document tracks ongoing findings from reviewing `Fulldecompile.c` as outlin
 ## Parameter Offsets
 Recent scanning around lines 31k uncovered several hardcoded offsets. The value stored at `local_1c + 0x9d40` is repeatedly printed as an RPM reading, while the variable at `local_1c + 0x9e84` acts as a divisor when it exceeds `0x10`. These addresses likely correspond to the motor speed register and a scaling factor for gear ratio or field weakening.
 
+Additional offsets identified:
+
+- `0x9d24` – bus voltage (divide by 10)
+- `0x9d28` – bus current (divide by 4)
+- `0x9d48` – throttle voltage sensor
+- `0xa074` – brake voltage sensor
+- `0x9e38` – output current *Iq*
+- `0x9e3c` – output current *Id*
+
 ## Next Steps
 - Identify where packets are parsed by searching for length fields immediately following the start byte.
 - Locate checksum logic by scanning for constants such as `0xA001` or loops operating on message bytes.
 - Map command codes to functions by examining switch statements or large `if/else` chains that handle packet `command` fields.
+
+- Trace handling of throttle and brake voltage around offsets `0x9d48` and `0xa074`.
+- Locate configuration data near `0x9e9c` to determine throttle mapping tables.
 

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -9,4 +9,8 @@ continues.
 |0x0002|`bus_voltage_v`   | volts |
 |0x0003|`bus_current_a`   | amps  |
 |0x0004|`motor_temp_c`   | °C    |
+|0x0005|`id_out_a`        | amps  |
+|0x0006|`iq_out_a`        | amps  |
+|0x0007|`throttle_voltage_v`| volts |
+|0x0008|`brake_voltage_v`| volts |
 

--- a/src/parsing/data_parser.py
+++ b/src/parsing/data_parser.py
@@ -32,3 +32,35 @@ class DataParser:
             raise ValueError("CRC mismatch")
         return ParsedMessage(command, payload)
 
+
+class StreamingDataParser:
+    """Incrementally parse incoming bytes into :class:`ParsedMessage` objects."""
+
+    def __init__(self) -> None:
+        self._buffer = bytearray()
+        self._parser = DataParser()
+
+    def feed(self, data: bytes) -> list[ParsedMessage]:
+        """Feed raw bytes and return any complete messages parsed."""
+        self._buffer.extend(data)
+        messages: list[ParsedMessage] = []
+        while True:
+            if len(self._buffer) < 4:
+                break
+            if self._buffer[0] != START_BYTE:
+                self._buffer.pop(0)
+                continue
+            length = self._buffer[1]
+            total = length + 2
+            if len(self._buffer) < total:
+                break
+            packet = bytes(self._buffer[:total])
+            try:
+                msg = self._parser.parse(packet)
+            except ValueError:
+                self._buffer.pop(0)
+                continue
+            messages.append(msg)
+            del self._buffer[:total]
+        return messages
+

--- a/src/parsing/parameter_map.py
+++ b/src/parsing/parameter_map.py
@@ -4,4 +4,9 @@ PARAMETERS = {
     0x0001: "motor_speed_rpm",
     0x0002: "bus_voltage_v",
     0x0003: "bus_current_a",
+    0x0004: "motor_temp_c",
+    0x0005: "id_out_a",
+    0x0006: "iq_out_a",
+    0x0007: "throttle_voltage_v",
+    0x0008: "brake_voltage_v",
 }

--- a/src/parsing/value_decoder.py
+++ b/src/parsing/value_decoder.py
@@ -11,6 +11,11 @@ SCALE = {
     "motor_speed_rpm": 1,
     "bus_voltage_v": 0.1,
     "bus_current_a": 0.1,
+    "motor_temp_c": 1,
+    "id_out_a": 0.1,
+    "iq_out_a": 0.1,
+    "throttle_voltage_v": 0.01,
+    "brake_voltage_v": 0.01,
 }
 
 

--- a/tests/test_data_parser.py
+++ b/tests/test_data_parser.py
@@ -5,7 +5,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from src.communication.protocol import Packet
-from src.parsing.data_parser import DataParser
+from src.parsing.data_parser import DataParser, StreamingDataParser
 
 
 def test_data_parser_roundtrip():
@@ -15,3 +15,20 @@ def test_data_parser_roundtrip():
     parsed = parser.parse(encoded)
     assert parsed.command == 0x01
     assert parsed.payload == b"\x02\x03"
+
+
+def test_streaming_parser_multiple_packets():
+    pkt1 = Packet(command=0x01, data=b"\x01")
+    pkt2 = Packet(command=0x02, data=b"\x03\x04")
+    enc1 = pkt1.encode()
+    enc2 = pkt2.encode()
+    stream = StreamingDataParser()
+
+    # feed partial first packet
+    assert stream.feed(enc1[:2]) == []
+    msgs = stream.feed(enc1[2:] + enc2)
+    assert len(msgs) == 2
+    assert msgs[0].command == pkt1.command
+    assert msgs[0].payload == b"\x01"
+    assert msgs[1].command == pkt2.command
+    assert msgs[1].payload == b"\x03\x04"


### PR DESCRIPTION
## Summary
- document additional parameter offsets from decompiled firmware
- update parameters table
- implement StreamingDataParser
- extend tests for stream parsing
- adjust README next steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436e12d7288320b71212f6bb78739f