### PR TITLE
Document parameter offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ The decompiled code contains memory addresses for all parameters. You need to fi
    - RPM values
    - Temperature sensors
    - Throttle position
+   - Example: `0x9d40` (RPM counter) scaled by `0x9e84`
 
 2. **Configuration Addresses**
    - Motor settings
@@ -461,6 +462,7 @@ HH:MM:SS.mmm,96.5,45.2,4361.4,3250,...,Test run 1
 - Configurable logging rate
 - Comment field for notes
 - Automatic file rotation
+- Implemented in `features/logging.py` via the `Logger` class
 
 ### 3. Parameter Tuning
 **Requirement**: Modify controller settings safely
@@ -589,6 +591,9 @@ ports = serial.tools.list_ports.comports()
 ### 1. CRC Implementation
 **THIS IS LIFE OR DEATH** - Without correct CRC, nothing works!
 
+See `docs/CRC_ALGORITHMS.md` for the firmware's CRC-16 implementation used by
+`src/communication/crc.py`.
+
 Look for in decompile:
 - CRC polynomial values
 - Byte-by-byte calculation loops
@@ -645,6 +650,16 @@ Requirements:
 2. Note data types (uint8, uint16, etc.)
 3. Document scaling factors
 4. Identify read vs write addresses
+
+Known offsets mapped so far:
+- `0x9d40` – motor RPM counter
+- `0x9e84` – RPM divisor used when above `0x10`
+- `0x9d24` – bus voltage (÷10)
+- `0x9d28` – bus current (÷4)
+- `0x9d48` – throttle voltage sensor
+- `0xa074` – brake voltage sensor
+- `0x9e38` – output current IQ (×0.1A)
+- `0x9e3c` – output current ID (×0.1A)
 
 ### Step 4: CRC Extraction
 1. Find CRC calculation function
@@ -726,7 +741,6 @@ The old version failed because it was incomplete. This version must expose EVERY
 
 Good luck, and remember: **This is life or death!** ⚡🏁
 ## NEXT STEPS
-- Document throttle and brake voltage offsets (`0x9d48` and `0xa074`).
-- Reverse configuration structures around `0x9e9c` for throttle mapping.
-- Integrate new ID/IQ current parameters into the UI.
+- Continue reversing structures near `0x9e9c` for throttle mapping.
+- Integrate remaining ID/IQ parameters into the UI and logging system.
 

--- a/docs/DECOMPILE_NOTES.md
+++ b/docs/DECOMPILE_NOTES.md
@@ -21,7 +21,12 @@ This document tracks ongoing findings from reviewing `Fulldecompile.c` as outlin
   rate and parity settings.
 
 ## Parameter Offsets
-Recent scanning around lines 31k uncovered several hardcoded offsets. The value stored at `local_1c + 0x9d40` is repeatedly printed as an RPM reading, while the variable at `local_1c + 0x9e84` acts as a divisor when it exceeds `0x10`. These addresses likely correspond to the motor speed register and a scaling factor for gear ratio or field weakening.
+Recent scanning around lines 31k uncovered several hardcoded offsets. The value
+stored at `local_1c + 0x9d40` is repeatedly printed as an RPM counter. When
+`0x9e84` is greater than `0x10` the firmware multiplies this RPM value by four
+and divides by the `0x9e84` register. This strongly suggests that `0x9e84`
+provides a divisor used to scale the raw speed for display, likely taking the
+gear ratio or field-weakening into account.
 
 Additional offsets identified:
 

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -13,4 +13,18 @@ continues.
 |0x0006|`iq_out_a`        | amps  |
 |0x0007|`throttle_voltage_v`| volts |
 |0x0008|`brake_voltage_v`| volts |
+|0x0009|`rpm_divisor`     | n/a   |
+
+## Firmware Offsets
+
+| Offset | Description                |
+|-------:|----------------------------|
+|`0x9d40`|Motor RPM counter           |
+|`0x9e84`|RPM divisor                 |
+|`0x9d24`|Bus voltage raw (÷10)       |
+|`0x9d28`|Bus current raw (÷4)        |
+|`0x9d48`|Throttle voltage sensor     |
+|`0xa074`|Brake voltage sensor        |
+|`0x9e38`|Output current IQ (×0.1A)   |
+|`0x9e3c`|Output current ID (×0.1A)   |
 

--- a/src/parsing/parameter_map.py
+++ b/src/parsing/parameter_map.py
@@ -9,4 +9,5 @@ PARAMETERS = {
     0x0006: "iq_out_a",
     0x0007: "throttle_voltage_v",
     0x0008: "brake_voltage_v",
+    0x0009: "rpm_divisor",
 }

--- a/src/parsing/value_decoder.py
+++ b/src/parsing/value_decoder.py
@@ -16,6 +16,7 @@ SCALE = {
     "iq_out_a": 0.1,
     "throttle_voltage_v": 0.01,
     "brake_voltage_v": 0.01,
+    "rpm_divisor": 1,
 }
 
 


### PR DESCRIPTION
## Summary
- extend parameter docs with motor speed offsets
- map rpm_divisor parameter
- document offsets and CRC reference in README
- note rpm scaling in decompile notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684370d825d8832088cca2d56b2bd5b1