### PR TITLE
Add protocol and parser tests

### DIFF
--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.communication.protocol import Packet, START_BYTE
+from src.communication.crc import crc16
+
+
+def test_packet_encode_format_and_crc():
+    pkt = Packet(command=0x55, data=b"\x01\x02")
+    encoded = pkt.encode()
+    # Start byte
+    assert encoded[0] == START_BYTE
+    # Length should equal data length + 3
+    assert encoded[1] == len(pkt.data) + 3
+    # Command byte
+    assert encoded[2] == 0x55
+    # Data bytes
+    assert encoded[3:5] == b"\x01\x02"
+    # CRC should match crc16 over payload (start,length,command,data)
+    expected_crc = crc16(encoded[:-2])
+    assert encoded[-2:] == expected_crc.to_bytes(2, "little")

--- a/tests/test_streaming_errors.py
+++ b/tests/test_streaming_errors.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.communication.protocol import Packet
+from src.parsing.data_parser import StreamingDataParser
+
+
+def test_streaming_parser_bad_crc_then_valid():
+    valid = Packet(command=0x01, data=b"\x02").encode()
+    # Corrupt last byte of CRC
+    bad = bytearray(valid)
+    bad[-1] ^= 0xFF
+    parser = StreamingDataParser()
+    # Feeding invalid packet should yield no messages
+    assert parser.feed(bytes(bad)) == []
+    # Now feed a valid packet
+    msgs = parser.feed(valid)
+    assert len(msgs) == 1
+    assert msgs[0].command == 0x01
+    assert msgs[0].payload == b"\x02"
+
+
+def test_streaming_parser_bad_length_then_valid():
+    valid = Packet(command=0x05, data=b"\x01\x02").encode()
+    bad = bytearray(valid)
+    # Decrease length field so it does not match actual length
+    bad[1] -= 1
+    parser = StreamingDataParser()
+    assert parser.feed(bytes(bad)) == []
+    msgs = parser.feed(valid)
+    assert len(msgs) == 1
+    assert msgs[0].command == 0x05
+    assert msgs[0].payload == b"\x01\x02"

--- a/tests/test_value_decoder.py
+++ b/tests/test_value_decoder.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.parsing.value_decoder import decode
+
+
+def test_decode_scaling():
+    assert decode(0x0002, 1234) == 123.4  # bus_voltage_v scale 0.1
+    assert decode(0x0007, 500) == 5.0      # throttle_voltage_v scale 0.01
+    assert decode(0x0004, 55) == 55        # motor_temp_c scale 1
+    assert decode(0xFFFF, 42) == 42        # unknown param


### PR DESCRIPTION
## Summary
- test value decoder scaling
- verify packet encoding format and CRC
- test streaming parser error handling for bad CRC and length

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684379459a1083208a566b78b3a785b9